### PR TITLE
Feat/tiny2 adapt

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -30,7 +30,7 @@ class Alert extends InputBase {
     this.buttonText = buttonText || '关闭';
 
     //constant
-    this.DPI = Tiny.config.dpi;
+    this.DPI = Tiny.config.dpi || 2;
     this.PADDING = 40 * this.DPI;
     this.CONTENT_FONTSIZE = 16 * this.DPI;
     this.BTN_FONTSIZE = 14 * this.DPI;
@@ -38,7 +38,7 @@ class Alert extends InputBase {
     this.MAX_WIDTH = Tiny.WIN_SIZE.width * 0.8;
   }
 
-  render(text) {
+  __render(text) {
     this.removeChildren(0, this.children.length);
     //渲染label
     this.label = this.drawLabel(text);
@@ -121,7 +121,7 @@ class Alert extends InputBase {
   alert(text, callback) {
     if (this.stage) {
       this.stage.removeChild(this);
-      this.render(text);
+      this.__render(text);
       this.stage.addChild(this);
       this.callback = callback;
     }

--- a/src/Label.js
+++ b/src/Label.js
@@ -36,10 +36,10 @@ class Label extends InputBase {
 
     this.settings = Object.assign({}, this.defaultSetting, options || {});
 
-    this.render();
+    this.__render();
   }
 
-  render() {
+  __render() {
     const {
       text,
       width,

--- a/src/TiledText.js
+++ b/src/TiledText.js
@@ -79,7 +79,13 @@ class TiledText {
 
   _update() {
     this.sprites.forEach(sprite => {
-      sprite.texture.updateUvs();
+      const texture = sprite.texture;
+      // updateUvs 兼容 Tiny1 和 Tiny2
+      if (texture._updateUvs) {
+        texture._updateUvs();
+      } else {
+        texture.updateUvs();
+      }
     });
   }
 

--- a/src/TiledText.js
+++ b/src/TiledText.js
@@ -79,7 +79,7 @@ class TiledText {
 
   _update() {
     this.sprites.forEach(sprite => {
-      sprite.texture._updateUvs();
+      sprite.texture.updateUvs();
     });
   }
 

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -27,7 +27,7 @@ class Toast extends InputBase {
     this.autoHideTime = autoHideTime || 2000;
 
     //constant
-    this.DPI = Tiny.config.dpi;
+    this.DPI = Tiny.config.dpi || 2;
     this.PADDING = 20 * this.DPI;
     this.CONTENT_FONTSIZE = 16 * this.DPI;
     this.MIN_HEIGHT = 20 * this.DPI;
@@ -43,7 +43,7 @@ class Toast extends InputBase {
     });
   };
 
-  render(text) {
+  __render(text) {
     this.removeChildren(0, this.children.length);
     //渲染label
     this.label = this.drawLabel(text);
@@ -107,7 +107,7 @@ class Toast extends InputBase {
   show(text) {
     if (this.stage) {
       this.stage.removeChild(this);
-      this.render(text);
+      this.__render(text);
       this.stage.addChild(this);
 
       const cd = new Tiny.ticker.CountDown({


### PR DESCRIPTION
适配Tiny2.0：
1. 插件内部的render方法需重命名，否则与Tiny2.0框架内部冲突；
2. Tiny2.0启动参数中去除了dpi，默认是2；
3. Tiny2.0中sprite.texture._updateUvs已重命名为sprite.texture.updateUvs，这里需要做适配。